### PR TITLE
fix: configuration changes don't take effect until restart.

### DIFF
--- a/Jellyfin.Plugin.DoViRemux/DownmuxWorkflow.cs
+++ b/Jellyfin.Plugin.DoViRemux/DownmuxWorkflow.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 using MediaBrowser.Common.Configuration;
-using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Common.Plugins;
 using MediaBrowser.Model.Dto;
 using Microsoft.Extensions.Logging;
 
@@ -12,18 +12,22 @@ namespace Jellyfin.Plugin.DoViRemux;
 // We only need to go as far as the mp4box step, and then the main
 // RemuxLibraryTask can handle the rest (it just copies the video
 // stream from our MP4 instead of the original MKV)
-public class DownmuxWorkflow(PluginConfiguration _configuration,
+public class DownmuxWorkflow(IPluginManager _pluginManager,
                              ILogger<DownmuxWorkflow> _logger,
                              IApplicationPaths _paths)
 {
     public async Task<string> Downmux(MediaSourceInfo mediaSource, CancellationToken token)
     {
+        var configuration = (_pluginManager.GetPlugin(Plugin.OurGuid)?.Instance as Plugin)?.Configuration
+            ?? throw new Exception("Can't get plugin configuration");
+
         string hevcStreamPath = $"/tmp/dovi_tool_{mediaSource.Id}.hevc";
         string downmuxPath = $"/tmp/{mediaSource.Id}_profile8.mp4";
 
         // extract the HEVC stream...
         using var ffmpeg = new Process()
         {
+            // technically this should use the configured path, since it can be overridden with a CLI argument
             StartInfo = new ProcessStartInfo("ffmpeg")
             {
                 Arguments = string.Join(" ", [
@@ -47,7 +51,7 @@ public class DownmuxWorkflow(PluginConfiguration _configuration,
         // and feed it into dovi_tool, discarding the enhancement layer
         using var doviTool = new Process()
         {
-            StartInfo = new ProcessStartInfo(_configuration.PathToDoviTool)
+            StartInfo = new ProcessStartInfo(configuration.PathToDoviTool)
             {
                 Arguments = string.Join(" ", [
                     "-m 2", // convert RPU to 8.1
@@ -86,7 +90,7 @@ public class DownmuxWorkflow(PluginConfiguration _configuration,
         // indicating it's now profile 8.1. I don't think ffmpeg can do this.
         using var mp4box = new Process()
         {
-            StartInfo = new ProcessStartInfo(_configuration.PathToMP4Box)
+            StartInfo = new ProcessStartInfo(configuration.PathToMP4Box)
             {
                 // no clue what any of this does, except for the dvp line
                 Arguments = string.Join(" ", [

--- a/Jellyfin.Plugin.DoViRemux/Registrations.cs
+++ b/Jellyfin.Plugin.DoViRemux/Registrations.cs
@@ -1,4 +1,3 @@
-using MediaBrowser.Common.Plugins;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Plugins;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,11 +8,6 @@ public class Registrations : IPluginServiceRegistrator
 {
     public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
     {
-        // bug: yes very clever, katie, but the plugin system creates a new instance of the configuration when a change is saved,
-        // and scheduled tasks are singletons (by virtue of IPluginManager being a singleton), so they won't see config changes.
-        serviceCollection.AddTransient(sp => (sp.GetRequiredService<IPluginManager>().GetPlugin(Plugin.OurGuid)?.Instance as Plugin)?.Configuration
-            ?? throw new InvalidOperationException("Plugin configuration not registered"));
-            
         serviceCollection.AddTransient<RemuxLibraryTask>();
         serviceCollection.AddTransient<CleanRemuxesTask>();
         serviceCollection.AddTransient<DownmuxWorkflow>();


### PR DESCRIPTION
A configuration change creates a totally new instance of the configuration object, so we need to discard the one we have. Since most things are singletons, that becomes impossible unless it's done via IPluginManager.

Fixes #5.