### PR TITLE
Fix Remux Dolby Vision MKVs task with Jellyfin 10.11 by avoiding GetUserByName

### DIFF
--- a/Jellyfin.Plugin.DoViRemux/Jellyfin.Plugin.DoViRemux.csproj
+++ b/Jellyfin.Plugin.DoViRemux/Jellyfin.Plugin.DoViRemux.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.10.6">
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,7 +1,7 @@
 name: "DoViRemux"
 guid: "2f215b63-1a73-4193-9102-78f84d027014"
-version: 3.2.0
-targetAbi: "10.10.6.0"
+version: 3.2.1
+targetAbi: "10.11.0.0"
 framework: "net8.0"
 owner: "katiekloss"
 overview: "Automatically remux Dolby Vision files"
@@ -12,9 +12,4 @@ category: "General"
 artifacts:
   - "Jellyfin.Plugin.DoViRemux.dll"
 changelog: |-
-  - Fixed an error on task start when no primary user is set
-  - Fixed remuxes crashing when the media has external subtitles
-  - Fixed configuration changes requiring a restart to take effect
-  - Improved logging for the 7.6 to 8.1 downmux processes
-  - Fixed a deadlock between ffmpeg and dovi_tool during downmuxes
-  - 7.6 downmuxing is no longer enabled by default after initial plugin installation
+  - Updated Jellyfin dependency compatibility to 10.11.x


### PR DESCRIPTION
## Summary

This PR fixes the `Remux Dolby Vision MKVs` scheduled task failing on Jellyfin 10.11.x with a `MissingMethodException`:

> System.MissingMethodException: Method not found: 'Jellyfin.Data.Entities.User MediaBrowser.Controller.Library.IUserManager.GetUserByName(System.String)'.

Jellyfin 10.11 removed or changed `IUserManager.GetUserByName(string)`, so the plugin crashes as soon as the scheduled task runs.

Fixes #12.

---

## Changes

- Update `RemuxLibraryTask` to resolve the configured *Primary User* without calling the removed `IUserManager.GetUserByName(string)` method.
- Instead, the task now:
  - Reads `configuration.PrimaryUser`,
  - Trims it and performs a case-insensitive lookup against `_userManager.Users` by `Name`,
  - Throws a clear exception if the configured user does not exist (same behavior as before, just via a different API).

The rest of the task logic (item query, remux conditions, FFmpeg invocation, etc.) is unchanged.

---
